### PR TITLE
Updated some metrics

### DIFF
--- a/fe/src/lib/_content/metrics/hp_feature_power_capacity.svx
+++ b/fe/src/lib/_content/metrics/hp_feature_power_capacity.svx
@@ -1,3 +1,3 @@
 #### Power capacity
 
-Capacity of heat pump model (in kW).
+Total installed capacity of the heat pump (in kW).

--- a/fe/src/lib/_content/metrics/hp_feature_power_capacity_sum.svx
+++ b/fe/src/lib/_content/metrics/hp_feature_power_capacity_sum.svx
@@ -1,3 +1,3 @@
 #### Total power capacity
 
-The sum of the power capacity for all installed heat pumps (in kW).
+The sum of the power capacity for all selected heat pumps (in kW).

--- a/fe/src/lib/_content/metrics/hp_feature_power_generation.svx
+++ b/fe/src/lib/_content/metrics/hp_feature_power_generation.svx
@@ -1,3 +1,3 @@
 #### Power generation
 
-Estimated energy produced by the heat pump in a year (in kW).
+Estimated energy produced by the heat pump in a year (in kWh).

--- a/fe/src/lib/_content/metrics/hp_feature_power_generation_sum.svx
+++ b/fe/src/lib/_content/metrics/hp_feature_power_generation_sum.svx
@@ -1,3 +1,3 @@
 #### Total power generation
 
-The sum of the estimated energy produced in a year by all all installed heat pumps (in kW).
+The sum of the estimated energy produced in a year by all selected heat pumps (in kWh).

--- a/fe/src/lib/_content/metrics/index.js
+++ b/fe/src/lib/_content/metrics/index.js
@@ -30,13 +30,11 @@ export {default as property_feature_built_form} from './property_feature_built_f
 export {default as property_feature_glazed_area} from './property_feature_glazed_area.svx';
 export {default as property_feature_glazed_type} from './property_feature_glazed_type.svx';
 export {default as property_feature_number_habitable_rooms} from './property_feature_number_habitable_rooms.svx';
-export {default as property_feature_total_floor_area_sum} from './property_feature_total_floor_area_sum.svx';
 export {default as property_feature_total_floor_area} from './property_feature_total_floor_area.svx';
 export {default as property_feature_type} from './property_feature_type.svx';
 export {default as property_supply_heating_fuel_type} from './property_supply_heating_fuel_type.svx';
 export {default as property_supply_heating_system} from './property_supply_heating_system.svx';
 export {default as property_supply_mains_gas_flag} from './property_supply_mains_gas_flag.svx';
-export {default as property_supply_photovoltaic_sum} from './property_supply_photovoltaic_sum.svx';
 export {default as property_supply_photovoltaic} from './property_supply_photovoltaic.svx';
 export {default as property_supply_solar_water_heating_flag} from './property_supply_solar_water_heating_flag.svx';
 export {default as property_tenure} from './property_tenure.svx';

--- a/fe/src/lib/_content/metrics/installation_cost_sum.svx
+++ b/fe/src/lib/_content/metrics/installation_cost_sum.svx
@@ -1,3 +1,3 @@
 #### Market value
 
-The sum of the installation cost of all installed heat pumps (in GBP).
+The sum of the installation cost of all selected heat pumps (in GBP).

--- a/fe/src/lib/_content/metrics/property_feature_total_floor_area_sum.svx
+++ b/fe/src/lib/_content/metrics/property_feature_total_floor_area_sum.svx
@@ -1,3 +1,0 @@
-#### Total floor area
-
-The total floor area of all the properties, measured in square meters.

--- a/fe/src/lib/_content/metrics/property_supply_photovoltaic.svx
+++ b/fe/src/lib/_content/metrics/property_supply_photovoltaic.svx
@@ -1,3 +1,5 @@
 #### Photovoltaic supply
 
-The photovoltaic (solar power) supply of the property (in kW).
+The photovoltaic area as a percentage of total roof area.
+
+0% indicates that a Photovoltaic Supply is not present in the property

--- a/fe/src/lib/_content/metrics/property_supply_photovoltaic_sum.svx
+++ b/fe/src/lib/_content/metrics/property_supply_photovoltaic_sum.svx
@@ -1,3 +1,0 @@
-#### Total photovoltaic supply
-
-The total photovoltaic supply of all the properties (in kW).

--- a/fe/src/lib/components/explorer/medium/PercentilesTrendsView.svelte
+++ b/fe/src/lib/components/explorer/medium/PercentilesTrendsView.svelte
@@ -6,7 +6,6 @@
 	import Grid2Columns from '$lib/components/svizzle/Grid2Columns.svelte';
 	import GridRows from '$lib/components/svizzle/GridRows.svelte';
 	import KeysLegend from '$lib/components/svizzle/legend/KeysLegend.svelte';
-	import Scroller from '$lib/components/svizzle/Scroller.svelte';
 	import StatsTrends from '$lib/components/svizzle/trends/StatsTrends.svelte';
 	import {_isSmallScreen} from '$lib/stores/layout.js';
 	import {_framesTheme} from '$lib/stores/theme.js';

--- a/fe/src/lib/statechart/actions/view.js
+++ b/fe/src/lib/statechart/actions/view.js
@@ -93,8 +93,6 @@ export const generateQueryPathFromSelectionStores = assign(ctx => {
 						case 'hp_feature_power_capacity_sum':
 						case 'hp_feature_power_generation_sum':
 						case 'installation_cost_sum':
-						case 'property_feature_total_floor_area_sum':
-						case 'property_supply_photovoltaic_sum':
 							endpoint = 'terms1_stats2';
 							params = {
 								field1: geoField,
@@ -149,8 +147,6 @@ export const generateQueryPathFromSelectionStores = assign(ctx => {
 						case 'hp_feature_power_capacity_sum':
 						case 'hp_feature_power_generation_sum':
 						case 'installation_cost_sum':
-						case 'property_feature_total_floor_area_sum':
-						case 'property_supply_photovoltaic_sum':
 							endpoint = 'stats';
 							params = {
 								field,
@@ -203,8 +199,6 @@ export const generateQueryPathFromSelectionStores = assign(ctx => {
 						case 'hp_feature_power_capacity_sum':
 						case 'hp_feature_power_generation_sum':
 						case 'installation_cost_sum':
-						case 'property_feature_total_floor_area_sum':
-						case 'property_supply_photovoltaic_sum':
 							endpoint = 'date_histogram1_stats2';
 							params = {
 								calendar_interval1: ctx.selection.interval,

--- a/fe/src/routes/explorer/count/geo/[slug]/+page.svelte
+++ b/fe/src/routes/explorer/count/geo/[slug]/+page.svelte
@@ -27,8 +27,6 @@
 		installers_dropped_certifications: getCertifiedValue,
 		installers_new_certifications: getCertifiedValue,
 		installers: getCardinalityValue,
-		property_feature_total_floor_area_sum: getStatsSum,
-		property_supply_photovoltaic_sum: getStatsSum,
 	}
 
 	$: proceed =

--- a/fe/src/routes/explorer/count/stats/[slug]/+page.svelte
+++ b/fe/src/routes/explorer/count/stats/[slug]/+page.svelte
@@ -28,8 +28,6 @@
 		installers_dropped_certifications: getCount,
 		installers_new_certifications: getCount,
 		installers: getCardinalityValue,
-		property_feature_total_floor_area_sum: getStatsSum,
-		property_supply_photovoltaic_sum: getStatsSum,
 	};
 
 	$: proceed =
@@ -78,11 +76,6 @@
 			case 'installers':
 				text = `${value} installers installed heat pumps for the current filter`;
 				break;
-			case 'property_feature_total_floor_area_sum':
-				text = `Total of ${fullValue} of floor area for the current filter`;
-				break;
-			case 'property_supply_photovoltaic_sum':
-				text = `${fullValue} installed photovoltaic energy generation for the current filter`;
 			default:
 				break;
 		}

--- a/fe/src/routes/explorer/count/time/[slug]/+page.svelte
+++ b/fe/src/routes/explorer/count/time/[slug]/+page.svelte
@@ -41,8 +41,6 @@
 		installers_dropped_certifications: getCardinalityValue,
 		installers_new_certifications: getCardinalityValue,
 		installers: getCardinalityValue,
-		property_feature_total_floor_area_sum: getStatsSum,
-		property_supply_photovoltaic_sum: getStatsSum,
 	}
 	const filterOutNils = _.filterWith(_.pipe([getValue, isNotNil]));
 

--- a/fe/src/routes/explorer/number/time/[slug]/+page.svelte
+++ b/fe/src/routes/explorer/number/time/[slug]/+page.svelte
@@ -107,7 +107,7 @@
 						name='numTimeGraph'
 						values={['percentiles', 'average']}
 					/>
-				</FlexBar>		
+				</FlexBar>
 			</GridRows>
 		</View>
 	{/if}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "nesta_hpmt",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "nesta_hpmt",
-			"version": "0.3.0",
+			"version": "0.3.1",
 			"license": "MIT",
 			"workspaces": [
 				"be",

--- a/shared/counts.js
+++ b/shared/counts.js
@@ -22,7 +22,7 @@ export const counts = [
 		isCumulative: true,
 		label: 'Total power generation',
 		type: 'count',
-		unitOfMeasure: 'kW',
+		unitOfMeasure: 'kWh',
 	},
 
 	/* Installation */
@@ -95,30 +95,5 @@ export const counts = [
 		label: 'Amount of new/renewed certificates',
 		title: 'Amount of new/renewed certificates',
 		type: 'count'
-	},
-
-	/* Property */
-
-	{
-		entity: 'Property',
-		field: 'property_feature_total_floor_area',
-		formatSpecifier: '.2s',
-		geoPrefix: 'property',
-		id: 'property_feature_total_floor_area_sum',
-		isCumulative: true,
-		label: 'Total floor area',
-		type: 'count',
-		unitOfMeasure: 'm^2',
-	},
-	{
-		entity: 'Property',
-		field: 'property_supply_photovoltaic',
-		formatSpecifier: '.3s',
-		geoPrefix: 'property',
-		id: 'property_supply_photovoltaic_sum',
-		isCumulative: true,
-		label: 'Total photovoltaic supply',
-		type: 'count',
-		unitOfMeasure: 'kW',
 	},
 ];

--- a/shared/fields.js
+++ b/shared/fields.js
@@ -34,7 +34,7 @@ export const fields = [
 		formatSpecifier: '.3s',
 		label: 'Power generation',
 		type: 'number',
-		unitOfMeasure: 'kW',
+		unitOfMeasure: 'kWh',
 	},
 	{
 		entity: 'Heat pump',
@@ -385,10 +385,10 @@ export const fields = [
 		entity: 'Property',
 		geoPrefix: 'property',
 		id: 'property_supply_photovoltaic',
-		formatSpecifier: '.3s',
+		formatSpecifier: '.1f',
 		label: 'Photovoltaic supply',
 		type: 'number',
-		unitOfMeasure: 'kW',
+		unitOfMeasure: '%',
 	},
 	{
 		entity: 'Property',


### PR DESCRIPTION
- Estimated annual generation: updated unit of measure to `kWh`
- Property Photovoltaic supply: this is the photovoltaic area as a percentage of total roof area. 0% indicates that a Photovoltaic Supply is not present in the property.
- Removed Total property Photovoltaic supply as given the above point it doesn't make sense to sum it

closes #345