### PR TITLE
Escaping `&` in param strings to avoid RISON parsing bug

### DIFF
--- a/fe/src/lib/utils/svizzle/url.js
+++ b/fe/src/lib/utils/svizzle/url.js
@@ -8,6 +8,14 @@ export const objectToSearchParams = _.pipe([
 	_.joinWith('&')
 ]);
 
+const escapeAmpersand = string => string.replace(/&/gu, '%26');
+
 export const risonifyValues = _.mapValuesWith(
-	_.when(_.anyOf([isArray, isObject]), RISON.stringify)
+	_.when(
+		_.anyOf([isArray, isObject]),
+		_.pipe([
+			RISON.stringify,
+			escapeAmpersand
+		])
+	)
 );


### PR DESCRIPTION
Closes #275
