### PR TITLE
Fix bug when no data is returned

### DIFF
--- a/be/src/hooks.js
+++ b/be/src/hooks.js
@@ -10,7 +10,7 @@ export const onRequest = async (request, reply) => {
 	let { field, field1, field2, filter = null } = request.query;
 
 	/* Special routes where field is not specified */
-	switch (request.routerPath) {
+	switch (request.routeOptions.url) {
 		case '/count':
 			field = '_id' // all fields have _id so only the filter will affect outcomes
 			break
@@ -70,7 +70,7 @@ export const formatPayload = async (request, reply, payload) => {
 			message: 'aggregation successful',
 			request: {
 				agg: {
-					id: request.routerPath.slice(1),
+					id: request.routeOptions.url.slice(1),
 					params: request.query
 				},
 				filter: request.filter

--- a/fe/src/lib/components/explorer/medium/QuickStatsMedium.svelte
+++ b/fe/src/lib/components/explorer/medium/QuickStatsMedium.svelte
@@ -2,11 +2,7 @@
 	import {setupResizeObserver} from '@svizzle/ui';
 
 	import {_staticData} from '$lib/stores/data.js';
-	import {
-		_noDataReturned,
-		_viewData,
-		_viewDataCoverage,
-	} from '$lib/stores/view.js';
+	import {_viewData, _viewDataCoverage} from '$lib/stores/view.js';
 
 	const {
 		_writable: _coverageSize,
@@ -30,7 +26,7 @@
 
 	const ratio = 0.8;
 
-	$: if ($_viewDataCoverage && $_coverageSize && !$_noDataReturned) {
+	$: if ($_viewDataCoverage && $_coverageSize) {
 
 		({blockSize: svgSide} = $_coverageSize);
 		({

--- a/fe/src/lib/components/layout/small/ExplorerSmall.svelte
+++ b/fe/src/lib/components/layout/small/ExplorerSmall.svelte
@@ -19,7 +19,7 @@
 	import {
 		_isViewLoading,
 		_showMessage,
-		_viewData,
+		_viewDataCoverage,
 		_viewDataMessage,
 	} from '$lib/stores/view.js';
 
@@ -41,8 +41,8 @@
 	$: $_showMessage && console.log('[backend]:', $_viewDataMessage);
 
 	let filtered;
-	$: if ($_viewData) {
-		({response: {coverage: {filtered}}} = $_viewData);
+	$: if ($_viewDataCoverage) {
+		({filtered} = $_viewDataCoverage);
 	}
 
 	const onViewSelected = ({detail: id}) => {

--- a/fe/src/lib/stores/view.js
+++ b/fe/src/lib/stores/view.js
@@ -29,9 +29,9 @@ export const _viewDataMessage = derived(
 /* coverage */
 
 export const _viewDataCoverage = derived(
-	[_staticData, _viewData],
-	([staticData, viewData]) => {
-		if (!viewData || !staticData) {
+	[_staticData, _viewData, _noDataReturned],
+	([staticData, viewData, noDataReturned]) => {
+		if (!viewData || !staticData || noDataReturned) {
 			return
 		}
 


### PR DESCRIPTION
We need to check the `$_noDataReturned` store carefully before proceeding to visualise the data.

Also:
   - Fixes the deprecation warning in the BE

fixes #395