### PR TITLE
`number|category/geo`: clear the tooltip when we exit from the barchart

### DIFF
--- a/fe/src/lib/components/explorer/CatGeoView2.svelte
+++ b/fe/src/lib/components/explorer/CatGeoView2.svelte
@@ -165,6 +165,9 @@
 		};
 	}
 	const onBarExited = () => {
+		clearTooltip();
+
+		// barchart
 		heroKey = null;
 	}
 

--- a/fe/src/lib/components/explorer/NumGeoView.svelte
+++ b/fe/src/lib/components/explorer/NumGeoView.svelte
@@ -106,7 +106,10 @@
 			y: $_mapGeometry.top + y,
 		};
 	}
-	const onBarExited = ({detail: {id}}) => {
+	const onBarExited = () => {
+		clearTooltip();
+
+		// barchart
 		heroKey = null;
 	}
 


### PR DESCRIPTION
fixes #481