### PR TITLE
fe: fixed mdsvex `_layout.svelte` loading for VSCode

### DIFF
--- a/fe/svelte.config.js
+++ b/fe/svelte.config.js
@@ -1,8 +1,15 @@
+import {dirname, join} from 'path';
+import {fileURLToPath} from 'url';
+
 import adapterAuto from '@sveltejs/adapter-auto';
 import adapterNetlify from '@sveltejs/adapter-netlify';
 import {mdsvex} from 'mdsvex';
 
 import {unescape_code} from './src/lib/utils/unescape-inlineCode.js';
+
+// https://github.com/sveltejs/language-tools/issues/1665
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const mdsvexLayout = join(__dirname, 'src/lib/components/mdsvex/_layout.svelte');
 
 // eslint-disable-next-line no-process-env
 const adapter = process.env.ADAPTER === 'netlify'
@@ -18,7 +25,7 @@ const config = {
 	kit: {adapter},
 	preprocess: [
 		mdsvex({
-			layout:'./src/lib/components/mdsvex/_layout.svelte',
+			layout: mdsvexLayout,
 			extensions: ['.svx', '.md'],
 			remarkPlugins: [unescape_code]
 		})


### PR DESCRIPTION
fixes #490
