### PR TITLE
fe/: adjusted view column widths to use `fr` units to avoid issues with gaps

### DIFF
--- a/be/src/es.js
+++ b/be/src/es.js
@@ -33,9 +33,9 @@ export const isOpenSearch = esEnv === 'production';
 
 // override search function to match the ES client
 if (esEnv === 'production') {
-	client.search = (function(_super) {
+	client.search = (function(super_) {
 		return async function() {
-			const result = await _super.apply(this, arguments);
+			const result = await super_.apply(this, arguments);
 
 			if ('body' in result) {
 				return result.body;

--- a/fe/src/lib/components/explorer/CatGeoView2.svelte
+++ b/fe/src/lib/components/explorer/CatGeoView2.svelte
@@ -381,8 +381,8 @@
 				/>
 			</GridColumns>
 			<GridColumns
-				colLayout='10% 59% 30%'
-				gap='1%'
+				colLayout='1fr 6fr 3fr'
+				gap='1em'
 			>
 				<div class='col0'>
 					{#if isSingleValue}

--- a/fe/src/lib/components/explorer/NumGeoView.svelte
+++ b/fe/src/lib/components/explorer/NumGeoView.svelte
@@ -299,8 +299,8 @@
 		</FlexBar>
 		{#if doDraw}
 			<GridColumns
-				colLayout='10% 59% 30%'
-				gap='1%'
+				colLayout='1fr 6fr 3fr'
+				gap='1em'
 			>
 				<div class='col0'>
 					{#if isSingleValue}

--- a/fe/src/lib/components/explorer/PercentilesTrendsView.svelte
+++ b/fe/src/lib/components/explorer/PercentilesTrendsView.svelte
@@ -121,8 +121,8 @@
 	</GridRows>
 {:else}
 	<GridColumns
-		colLayout='84% 15%'
-		gap='1%'
+		colLayout='85fr 15fr'
+		gap='1em'
 	>
 		<StatsTrends
 			{axesLabels}

--- a/fe/src/lib/components/explorer/StringGeoView.svelte
+++ b/fe/src/lib/components/explorer/StringGeoView.svelte
@@ -210,8 +210,8 @@
 
 		{#if doDraw}
 			<GridColumns
-				colLayout='25% 74%'
-				gap='1%'
+				colLayout='25fr 75fr'
+				gap='1em'
 			>
 				<Scroller alignVertically={true}>
 					<KeysLegend

--- a/fe/src/lib/components/explorer/medium/unused/CatGeoView.svelte
+++ b/fe/src/lib/components/explorer/medium/unused/CatGeoView.svelte
@@ -144,8 +144,8 @@
 		/>
 		<div class='gridcontainer'>
 			<GridColumns
-				colLayout='15% 84%'
-				gap='1%'
+				colLayout='15fr 85fr'
+				gap='1em'
 			>
 				<div class='col0'>
 					<div class='legend'>

--- a/fe/src/lib/components/svizzle/barchart/BarchartVDiv.svelte
+++ b/fe/src/lib/components/svizzle/barchart/BarchartVDiv.svelte
@@ -122,7 +122,7 @@
 
 	$: ({inlineSize: width, blockSize: height} = $_size);
 	$: availableWidth = Math.max(
-		width - geometry.padding - scrollbarWidth ?? 0,
+		width - scrollbarWidth ?? 0,
 		0
 	);
 	$: barPadding = geometry.glyphWidth;
@@ -298,7 +298,9 @@
 
 	$: refHeight = geometry.padding + geometry.glyphHeight;
 	$: refsHeight =
-		refs && refs.length * (geometry.padding + refHeight) + geometry.padding
+		refs &&
+		refs.length * (geometry.padding + refHeight) +
+		(refs.length > 0 ? geometry.padding : 0)
 		|| 0;
 	$: makeRefsLayout = pipe([
 		sortByValue,

--- a/fe/src/lib/stores/geometry.js
+++ b/fe/src/lib/stores/geometry.js
@@ -15,6 +15,6 @@ export const _barchartGeometry = derived(
 	glyph => ({
 		glyphHeight: glyph?.height,
 		glyphWidth: glyph?.width,
-		padding: 5, // FIXME can't be zero or values will overflow slightly
+		padding: 0,
 	})
 );

--- a/fe/src/routes/explorer/category/stats/[slug]/+page.svelte
+++ b/fe/src/routes/explorer/category/stats/[slug]/+page.svelte
@@ -126,8 +126,8 @@
 		</View>
 	{:else}
 		<GridColumns
-			colLayout='69% 30%'
-			gap='1%'
+			colLayout='7fr 3fr'
+			gap='1em'
 		>
 			<div class='treemap'>
 				<Treemap

--- a/fe/src/routes/explorer/category/time/[slug]/+page.svelte
+++ b/fe/src/routes/explorer/category/time/[slug]/+page.svelte
@@ -259,8 +259,8 @@
 
 		{#if doDraw}
 			<GridColumns
-				colLayout='84% 15%'
-				gap='1%'
+				colLayout='85fr 15fr'
+				gap='1em'
 			>
 				<div class='col'>
 					{#if $_selection.categsTimeGraph === 'streams'}

--- a/fe/src/routes/explorer/number/stats/[slug]/+page.svelte
+++ b/fe/src/routes/explorer/number/stats/[slug]/+page.svelte
@@ -143,8 +143,8 @@
 		</View>
 	{:else}
 		<GridColumns
-			colLayout='69% 30%'
-			gap='1%'
+			colLayout='7fr 3fr'
+			gap='1em'
 		>
 			<div class='col'>
 				<div class='treemap'>

--- a/fe/src/routes/explorer/string/stats/[slug]/+page.svelte
+++ b/fe/src/routes/explorer/string/stats/[slug]/+page.svelte
@@ -131,8 +131,8 @@
 		</View>
 	{:else}
 		<GridColumns
-			colLayout='69% 30%'
-			gap='1%'
+			colLayout='7fr 3fr'
+			gap='1em'
 		>
 			<div class='col'>
 				<div class='treemap'>

--- a/fe/src/routes/explorer/string/time/[slug]/+page.svelte
+++ b/fe/src/routes/explorer/string/time/[slug]/+page.svelte
@@ -273,8 +273,8 @@
 
 		{#if doDraw}
 			<GridColumns
-				colLayout='79% 20%'
-				gap='1%'
+				colLayout='8fr 2fr'
+				gap='1em'
 			>
 				<div class='col'>
 					{#if showStreams}


### PR DESCRIPTION
fixes #560

also:
- fixed `BarchartVDiv` width/height computations
- set bar charts padding to 0